### PR TITLE
Fix bullet destroying multiple characters

### DIFF
--- a/assets/js/retro-game.js
+++ b/assets/js/retro-game.js
@@ -59,8 +59,14 @@
     const els = document.elementsFromPoint(x, y);
     for (const el of els) {
       if (el === canvas || el.tagName === 'BODY' || el.contains(canvas)) continue;
-      if (el.firstChild && el.firstChild.nodeType === Node.TEXT_NODE) {
-        el.firstChild.nodeValue = el.firstChild.nodeValue.substring(1);
+
+      // Attempt to remove a single character from the first text node inside
+      // the hit element. This prevents entire blocks from disappearing when
+      // bullets collide with non-text elements.
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+      const textNode = walker.nextNode();
+      if (textNode) {
+        textNode.nodeValue = textNode.nodeValue.substring(1);
       } else {
         el.style.visibility = 'hidden';
       }


### PR DESCRIPTION
## Summary
- ensure bullets don't delete more than a single character

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*